### PR TITLE
Add Zeek's Python module directory to the search path

### DIFF
--- a/trace-summary
+++ b/trace-summary
@@ -19,6 +19,14 @@ VERSION = "0.91-14" # Automatically filled in.
 
 random.seed()
 
+# For Zeek-bundled installation, explictly add the Python path we've
+# installed ourselves under, so we find the SubnetTree module:
+ZEEK_PYTHON_DIR = '@PY_MOD_INSTALL_DIR@'
+if os.path.isdir(ZEEK_PYTHON_DIR):
+    sys.path.append(os.path.abspath(ZEEK_PYTHON_DIR))
+else:
+    ZEEK_PYTHON_DIR = None
+
 import SubnetTree
 
 class IntervalUpdate:


### PR DESCRIPTION
The Zeek distribuition's installed `trace-summary` script currently doesn't find the SubnetTree module. This is independent of the current Python folder work ... I think it's just a bug. Let me know if I'm missing something ... thanks. I think you'll see something like this:
```
$ ./trace-summary
Traceback (most recent call last):
  File "./trace-summary", line 22, in <module>
    import SubnetTree
ModuleNotFoundError: No module named 'SubnetTree'
```